### PR TITLE
feat: use `<time>` tag for datetime

### DIFF
--- a/src/postData.js
+++ b/src/postData.js
@@ -31,6 +31,7 @@ export default async function postData(document, filename, year) {
 
   // Treat date as PST.
   const date = new Date(Date.parse(`${year}-${month}-${day} PST`));
+  const isoDate = date.toISOString();
   const formattedDate = date.toLocaleDateString("en-US", {
     day: "numeric",
     month: "long",
@@ -72,6 +73,7 @@ export default async function postData(document, filename, year) {
   return Object.assign(
     {
       date,
+      isoDate,
       formattedDate,
       html,
       path,

--- a/src/postFragment.ori
+++ b/src/postFragment.ori
@@ -2,7 +2,7 @@
   <article>
     <a class="quiet" href="/${ post/path }">
       ${ post/title ? `<h1 class="postHeader">${ post/title }</h1>` : "" }
-      <p class="postDate">${ post/formattedDate }</p>
+      <time datetime=${ post/isoDate } class="postDate">${ post/formattedDate }</time>
     </a>
 ${ post/html }
   </article>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0bd34544-7d4e-4676-ba25-c115bcf91e41)

using [`<time>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time) tag helps with accessibility, e.g screen reader.

see: https://shkspr.mobi/blog/2020/12/making-time-more-accessible/ 